### PR TITLE
Manage domain cron job execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
+### PHP Domain Cron Worker (OOP, Forking Scheduler)
+
+This worker schedules and runs up to N cron-like tasks per domain using PHP CLI with pcntl forking. Each task is defined once and scheduled for each domain with its own interval.
+
+#### Requirements
+- PHP 8.1+ CLI
+- pcntl and posix extensions enabled
+
+#### Structure
+- `bootstrap.php`: PSR-4 autoloader and env checks
+- `worker.php`: CLI entrypoint
+- `config/domains.php`: Domains and their task definitions (intervals)
+- `src/Contracts`: `TaskInterface`, `ClockInterface`
+- `src/Tasks`: Example tasks `HttpPingTask`, `PhpScriptTask`
+- `src/Scheduler`: `Scheduler`, `JobQueue`, `JobDescriptor`
+- `src/Process`: `ProcessManager`
+
+#### Configure domains and tasks
+Edit `config/domains.php`:
+
+```php
+return [
+  'domain-a.com' => [
+    [ 'type' => 'http_ping', 'interval' => 60, 'path' => '/' ],
+    [ 'type' => 'php_script', 'interval' => 300, 'script' => __DIR__ . '/../scripts/sample_task.php' ],
+  ],
+  'domain-b.com' => [
+    [ 'type' => 'http_ping', 'interval' => 300 ],
+  ],
+];
+```
+
+Supported `type` values:
+- `http_ping`: options `interval`, `path`
+- `php_script`: options `interval`, `script`
+
+#### Run
+
+```bash
+php /workspace/worker.php --config=/workspace/config/domains.php \
+  --max-procs=100 --max-per-domain=2 --tick-ms=200
+```
+
+Stop with Ctrl+C or send SIGTERM to the process.
+
+#### Notes
+- Scheduler ensures per-domain concurrency limit and global max processes.
+- Each job re-schedules itself after it runs based on its `interval`.
+- Extend by implementing `App\Contracts\TaskInterface` and mapping in `worker.php`.
+
 # php-cron-worker

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+// Simple PSR-4 autoloader for the App\\ namespace without Composer
+spl_autoload_register(function (string $class): void {
+    $prefix = 'App\\';
+    if (strncmp($class, $prefix, strlen($prefix)) !== 0) {
+        return; // not our namespace
+    }
+    $relative = substr($class, strlen($prefix));
+    $path = __DIR__ . '/src/' . str_replace('\\', '/', $relative) . '.php';
+    if (is_file($path)) {
+        require_once $path;
+    }
+});
+
+// Environment checks
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "This worker must be run from the CLI.\n");
+    exit(1);
+}
+
+if (!function_exists('pcntl_fork')) {
+    fwrite(STDERR, "The pcntl extension is required. Enable it in your PHP CLI.\n");
+    exit(1);
+}
+
+if (!function_exists('posix_kill')) {
+    fwrite(STDERR, "The posix extension is required. Enable it in your PHP CLI.\n");
+    exit(1);
+}
+

--- a/config/domains.php
+++ b/config/domains.php
@@ -1,0 +1,13 @@
+<?php
+return [
+    // Each domain maps to an array of task definitions
+    // name => [ 'type' => class or alias, 'interval' => seconds, ...params ]
+    'example.com' => [
+        [ 'type' => 'http_ping', 'interval' => 60, 'path' => '/' ],
+        [ 'type' => 'php_script', 'interval' => 300, 'script' => __DIR__ . '/../scripts/sample_task.php' ],
+    ],
+    'example.org' => [
+        [ 'type' => 'http_ping', 'interval' => 300, 'path' => '/' ],
+    ],
+];
+

--- a/scripts/sample_task.php
+++ b/scripts/sample_task.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+
+// Simple demo script. Accepts domain as argv[1]
+$domain = $argv[1] ?? 'unknown-domain';
+fwrite(STDOUT, sprintf("Sample script ran for %s at %s\n", $domain, date('c')));
+

--- a/src/Contracts/ClockInterface.php
+++ b/src/Contracts/ClockInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+interface ClockInterface
+{
+    public function now(): int; // unix timestamp seconds
+    public function sleep(float $seconds): void;
+}
+

--- a/src/Contracts/TaskInterface.php
+++ b/src/Contracts/TaskInterface.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+interface TaskInterface
+{
+    public function getName(): string;
+
+    // Interval in seconds between runs (e.g., 60, 300)
+    public function getIntervalSeconds(): int;
+
+    // Execute the task logic for a specific domain
+    public function run(string $domain): void;
+}
+

--- a/src/Process/ProcessManager.php
+++ b/src/Process/ProcessManager.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Process;
+
+use App\Scheduler\JobDescriptor;
+use App\Contracts\ClockInterface;
+
+final class ProcessManager
+{
+    /** @var array<int, array{domain:string, task:string, started_at:int}> */
+    private array $children = [];
+
+    public function __construct(
+        private readonly ClockInterface $clock,
+        private readonly int $maxGlobalProcesses = 50,
+        private readonly int $maxPerDomainProcesses = 2
+    ) {}
+
+    public function canSpawn(string $domain): bool
+    {
+        if (count($this->children) >= $this->maxGlobalProcesses) {
+            return false;
+        }
+        $perDomain = 0;
+        foreach ($this->children as $child) {
+            if ($child['domain'] === $domain) {
+                $perDomain++;
+            }
+        }
+        return $perDomain < $this->maxPerDomainProcesses;
+    }
+
+    public function spawn(JobDescriptor $job): void
+    {
+        $pid = pcntl_fork();
+        if ($pid === -1) {
+            throw new \RuntimeException('Failed to fork');
+        }
+        if ($pid === 0) {
+            // Child process
+            $this->runChild($job);
+            exit(0);
+        }
+        $this->children[$pid] = [
+            'domain' => $job->domain,
+            'task' => $job->task->getName(),
+            'started_at' => $this->clock->now(),
+        ];
+    }
+
+    private function runChild(JobDescriptor $job): void
+    {
+        // Isolate signals
+        pcntl_async_signals(true);
+        pcntl_signal(SIGTERM, function (): void {
+            exit(0);
+        });
+        $job->task->run($job->domain);
+    }
+
+    public function reap(): void
+    {
+        // Non-blocking wait for any child
+        while (true) {
+            $status = 0;
+            $pid = pcntl_waitpid(-1, $status, WNOHANG);
+            if ($pid <= 0) {
+                break;
+            }
+            unset($this->children[$pid]);
+        }
+    }
+
+    public function activeCount(): int
+    {
+        return count($this->children);
+    }
+}
+

--- a/src/Scheduler/JobDescriptor.php
+++ b/src/Scheduler/JobDescriptor.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Scheduler;
+
+use App\Contracts\TaskInterface;
+
+final class JobDescriptor
+{
+    public function __construct(
+        public readonly string $domain,
+        public readonly TaskInterface $task,
+        public int $nextRunAt
+    ) {}
+}
+

--- a/src/Scheduler/JobQueue.php
+++ b/src/Scheduler/JobQueue.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Scheduler;
+
+/**
+ * Min-heap priority queue ordered by nextRunAt timestamp.
+ */
+final class JobQueue extends \SplPriorityQueue
+{
+    public function compare($priority1, $priority2): int
+    {
+        // SplPriorityQueue extracts highest priority first.
+        // We want the earliest nextRunAt first, so invert sign.
+        return $priority2 <=> $priority1;
+    }
+}
+

--- a/src/Scheduler/Scheduler.php
+++ b/src/Scheduler/Scheduler.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Scheduler;
+
+use App\Contracts\ClockInterface;
+use App\Process\ProcessManager;
+
+final class Scheduler
+{
+    /** @var JobQueue */
+    private JobQueue $queue;
+
+    public function __construct(
+        private readonly ClockInterface $clock,
+        private readonly ProcessManager $processManager
+    ) {
+        $this->queue = new JobQueue();
+    }
+
+    public function addJob(JobDescriptor $job): void
+    {
+        $this->queue->insert($job, $job->nextRunAt);
+    }
+
+    public function runLoop(int $tickSleepMs = 200): void
+    {
+        pcntl_async_signals(true);
+        $shouldRun = true;
+        pcntl_signal(SIGTERM, function () use (&$shouldRun): void { $shouldRun = false; });
+        pcntl_signal(SIGINT, function () use (&$shouldRun): void { $shouldRun = false; });
+
+        while ($shouldRun) {
+            $now = $this->clock->now();
+
+            // Reap finished children
+            $this->processManager->reap();
+
+            // Try to dispatch ready jobs
+            $dispatched = false;
+            $pending = [];
+            while (!$this->queue->isEmpty()) {
+                /** @var JobDescriptor $job */
+                $job = $this->queue->extract();
+                if ($job->nextRunAt > $now) {
+                    $pending[] = $job; // not ready yet
+                    break;
+                }
+                if ($this->processManager->canSpawn($job->domain)) {
+                    $this->processManager->spawn($job);
+                    $job->nextRunAt = $now + max(1, $job->task->getIntervalSeconds());
+                    $this->queue->insert($job, $job->nextRunAt);
+                    $dispatched = true;
+                } else {
+                    // Cannot spawn now; requeue without delay to attempt soon
+                    $pending[] = $job;
+                    break;
+                }
+            }
+            // push back any pending items
+            foreach ($pending as $job) {
+                $this->queue->insert($job, $job->nextRunAt);
+            }
+
+            if (!$dispatched) {
+                $this->clock->sleep($tickSleepMs / 1000);
+            }
+        }
+    }
+}
+

--- a/src/Support/SystemClock.php
+++ b/src/Support/SystemClock.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Contracts\ClockInterface;
+
+final class SystemClock implements ClockInterface
+{
+    public function now(): int
+    {
+        return time();
+    }
+
+    public function sleep(float $seconds): void
+    {
+        usleep((int) round($seconds * 1_000_000));
+    }
+}
+

--- a/src/Tasks/HttpPingTask.php
+++ b/src/Tasks/HttpPingTask.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tasks;
+
+use App\Contracts\TaskInterface;
+
+final class HttpPingTask implements TaskInterface
+{
+    public function __construct(
+        private readonly int $intervalSeconds = 60,
+        private readonly string $path = '/'
+    ) {}
+
+    public function getName(): string
+    {
+        return 'http_ping';
+    }
+
+    public function getIntervalSeconds(): int
+    {
+        return $this->intervalSeconds;
+    }
+
+    public function run(string $domain): void
+    {
+        $url = 'https://' . $domain . $this->path;
+        $status = '';
+        if (function_exists('curl_init')) {
+            $ch = curl_init($url);
+            curl_setopt_array($ch, [
+                CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_CONNECTTIMEOUT => 5,
+                CURLOPT_TIMEOUT => 10,
+                CURLOPT_NOBODY => true,
+                CURLOPT_FOLLOWLOCATION => true,
+                CURLOPT_USERAGENT => 'DomainCronWorker/1.0',
+            ]);
+            curl_exec($ch);
+            $err = curl_error($ch);
+            $code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            curl_close($ch);
+            $status = $err ? 'ERROR: ' . $err : 'HTTP ' . $code;
+        } else {
+            $context = stream_context_create([
+                'http' => [
+                    'method' => 'HEAD',
+                    'timeout' => 10,
+                    'ignore_errors' => true,
+                    'header' => "User-Agent: DomainCronWorker/1.0\r\n",
+                ],
+                'ssl' => [
+                    'verify_peer' => true,
+                    'verify_peer_name' => true,
+                ],
+            ]);
+            $headers = @get_headers($url, false, $context);
+            if ($headers === false) {
+                $status = 'ERROR: get_headers failed';
+            } else {
+                $first = is_array($headers) && isset($headers[0]) ? (string) $headers[0] : '';
+                $status = $first !== '' ? $first : 'OK';
+            }
+        }
+        fwrite(STDOUT, sprintf("[%s] %s %s => %s\n", date('c'), $domain, $this->getName(), $status));
+    }
+}
+

--- a/src/Tasks/PhpScriptTask.php
+++ b/src/Tasks/PhpScriptTask.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tasks;
+
+use App\Contracts\TaskInterface;
+
+/**
+ * Invokes a PHP script via CLI for the domain.
+ * Your script should accept the domain as first arg.
+ */
+final class PhpScriptTask implements TaskInterface
+{
+    public function __construct(
+        private readonly string $scriptPath,
+        private readonly int $intervalSeconds
+    ) {}
+
+    public function getName(): string
+    {
+        return 'php_script:' . basename($this->scriptPath);
+    }
+
+    public function getIntervalSeconds(): int
+    {
+        return $this->intervalSeconds;
+    }
+
+    public function run(string $domain): void
+    {
+        $cmd = escapeshellcmd(PHP_BINARY) . ' ' . escapeshellarg($this->scriptPath) . ' ' . escapeshellarg($domain);
+        $descriptorSpec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $process = proc_open($cmd, $descriptorSpec, $pipes);
+        if (!\is_resource($process)) {
+            fwrite(STDERR, sprintf("[%s] Failed to start script for %s: %s\n", date('c'), $domain, $cmd));
+            return;
+        }
+        fclose($pipes[0]);
+        stream_set_blocking($pipes[1], false);
+        stream_set_blocking($pipes[2], false);
+        $out = stream_get_contents($pipes[1]);
+        $err = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($process);
+        fwrite(STDOUT, sprintf("[%s] %s %s exit=%d\n", date('c'), $domain, $this->getName(), $exit));
+        if ($out !== '') {
+            fwrite(STDOUT, trim($out) . "\n");
+        }
+        if ($err !== '') {
+            fwrite(STDERR, trim($err) . "\n");
+        }
+    }
+}
+

--- a/worker.php
+++ b/worker.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/bootstrap.php';
+
+use App\Support\SystemClock;
+use App\Process\ProcessManager;
+use App\Scheduler\{Scheduler, JobDescriptor};
+use App\Tasks\{HttpPingTask, PhpScriptTask};
+
+// CLI options
+$opts = getopt('', [
+    'config::',
+    'max-procs::',
+    'max-per-domain::',
+    'tick-ms::',
+]);
+
+$configFile = $opts['config'] ?? __DIR__ . '/config/domains.php';
+if (!is_file($configFile)) {
+    fwrite(STDERR, "Config file not found: {$configFile}\n");
+    exit(1);
+}
+
+/** @var array<string, array<int, array<string, mixed>>> $domainConfig */
+$domainConfig = require $configFile;
+
+$clock = new SystemClock();
+$processManager = new ProcessManager(
+    $clock,
+    (int) ($opts['max-procs'] ?? 100),
+    (int) ($opts['max-per-domain'] ?? 2)
+);
+$scheduler = new Scheduler($clock, $processManager);
+
+// Build tasks per domain
+foreach ($domainConfig as $domain => $tasks) {
+    foreach ($tasks as $taskDef) {
+        $type = $taskDef['type'] ?? '';
+        $interval = (int) ($taskDef['interval'] ?? 60);
+        $task = match ($type) {
+            'http_ping' => new HttpPingTask($interval, (string) ($taskDef['path'] ?? '/')),
+            'php_script' => new PhpScriptTask((string) $taskDef['script'], $interval),
+            default => null,
+        };
+        if ($task === null) {
+            fwrite(STDERR, sprintf("Unknown task type '%s' for domain %s\n", (string)$type, (string)$domain));
+            continue;
+        }
+        $scheduler->addJob(new JobDescriptor($domain, $task, time()));
+    }
+}
+
+$tick = (int) ($opts['tick-ms'] ?? 200);
+fwrite(STDOUT, sprintf("Starting worker with %d domains. Tick=%dms\n", count($domainConfig), $tick));
+$scheduler->runLoop($tick);
+


### PR DESCRIPTION
Add a PHP OOP worker system for domain-specific cron jobs, featuring a forking scheduler, process manager, and configurable concurrency.

---
<a href="https://cursor.com/background-agent?bcId=bc-20b3ce14-cf82-4fee-a6d1-e02f36256e6b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-20b3ce14-cf82-4fee-a6d1-e02f36256e6b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

